### PR TITLE
feat: Add admin API tests and database functions for domain management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+- Unreleased:
+  - New
+    - Admin API to list registered domains, inspect their details, set TXT values, delete domains and gather usage statistics (`/admin/domains`, `/admin/domains/<subdomain>`, `/admin/domains/<subdomain>/txt`, `/admin/report`). Protected by an API key and an optional source IP allowlist, see the `[admin]` configuration section.
+  - Changed
+    - Migrated the DNS server from `github.com/miekg/dns` to its successor `codeberg.org/miekg/dns`.
+    - Responses to EDNS0 queries now advertise a UDP payload size of 1232 bytes instead of 512.
+    - Requires Go 1.27.
 - v0.10:
   - Switched to go 1.20
 - v0.9.1:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For longer explanation of the underlying issue and other proposed solutions, see
 - Custom records (have your required A, AAAA, NS, etc. records served)
 - HTTP API automatically acquires and uses Let's Encrypt TLS certificate
 - Limit /update API endpoint access to specific CIDR mask(s), defined in the /register request
+- Optional admin API to list, inspect, update and delete registered domains and to gather usage statistics, protected by an API key and an optional source IP allowlist. Suited for integrating acme-dns with a central ACME proxy.
 - Supports SQLite & PostgreSQL as DB backends
 - Rolling update of two TXT records to be able to answer to challenges for certificates that have both names: `yourdomain.tld` and `*.yourdomain.tld`, as both of the challenges point to the same subdomain.
 - Simple deployment (it's Go after all)
@@ -107,6 +108,134 @@ The method allows you to update the TXT answer contents of your unique subdomain
 The method can be used to check readiness and/or liveness of the server. It will return status code 200 on success or won't be reachable.
 
 `GET /health`
+
+## Admin API
+
+The admin API lets operators (or a central ACME proxy) list, inspect, update and delete registered domains without knowing the per-domain credentials. It is disabled by default and has to be enabled in the `[admin]` section of the configuration. All admin endpoints are served by the same HTTP(S) listener as the regular API.
+
+| Method | Path                              | Description                                         |
+| ------ | --------------------------------- | --------------------------------------------------- |
+| GET    | `/admin/domains`                  | List registered domains (paginated)                 |
+| GET    | `/admin/domains/<subdomain>`      | Details of one domain                               |
+| POST   | `/admin/domains/<subdomain>/txt`  | Set a TXT value (rolling update like `/update`)     |
+| DELETE | `/admin/domains/<subdomain>`      | Delete a domain including its TXT records           |
+| GET    | `/admin/report`                   | Usage statistics                                    |
+
+### Authentication
+
+Every request needs the configured `api_key`, which has to be at least 32 characters long. It can be sent in one of two ways:
+
+| Header name   | Example                                                  |
+| ------------- | -------------------------------------------------------- |
+| X-Admin-Key   | `X-Admin-Key: 4a7d1ed414474e4033ac29ccb8653d9b...`       |
+| Authorization | `Authorization: Bearer 4a7d1ed414474e4033ac29ccb8653d9b...` |
+
+Optionally, `allow_from` restricts access to a list of CIDR ranges. Requests from other addresses are rejected with `403 Forbidden` before the API key is checked. The client address is taken from the connection, or from the header configured with `use_header` / `header_name` in the `[api]` section when acme-dns runs behind a reverse proxy. Only enable `use_header` if the proxy overwrites that header, otherwise clients can spoof their address.
+
+A missing or wrong API key results in `401 Unauthorized`.
+
+### List domains
+
+`GET /admin/domains?limit=100&offset=0`
+
+Returns registered subdomains ordered by subdomain. `limit` defaults to 100 and is capped at 1000, `offset` defaults to 0. Password hashes are never returned.
+
+`Status: 200 OK`
+
+```json
+{
+  "total": 2,
+  "limit": 100,
+  "offset": 0,
+  "domains": [
+    {
+      "username": "c36f50e8-4632-44f0-83fe-e070fef28a10",
+      "subdomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a",
+      "fulldomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a.auth.example.org",
+      "allowfrom": ["192.168.100.1/24"],
+      "txt_records": [
+        { "txt": "___validation_token_received_from_the_ca___", "last_update": "2026-09-05T10:12:42Z" },
+        { "txt": "", "last_update": null }
+      ],
+      "has_txt": true,
+      "last_update": "2026-09-05T10:12:42Z"
+    }
+  ]
+}
+```
+
+### Domain details
+
+`GET /admin/domains/<subdomain>`
+
+Returns the same object as a list entry for a single subdomain. Unknown subdomains result in `404 Not Found`, syntactically invalid ones in `400 Bad Request`.
+
+### Set TXT value
+
+`POST /admin/domains/<subdomain>/txt`
+
+Sets the TXT value of a domain without the per-domain credentials. Like `/update` this performs a rolling update of the two stored TXT values, so two consecutive calls (for example for `example.org` and `*.example.org`) result in both values being served. The value has to be exactly 43 characters long.
+
+#### Example input
+
+```json
+{
+  "txt": "___validation_token_received_from_the_ca___"
+}
+```
+
+`Status: 200 OK`
+
+The response is the domain object as returned by the details endpoint, including the updated `txt_records`. Unknown subdomains result in `404 Not Found`, an invalid value in `400 Bad Request` with error `bad_txt`.
+
+### Delete domain
+
+`DELETE /admin/domains/<subdomain>`
+
+Removes the registration and its TXT records. The credentials of the domain stop working immediately.
+
+`Status: 204 No Content`
+
+Unknown subdomains result in `404 Not Found`.
+
+### Report
+
+`GET /admin/report`
+
+Returns aggregated usage statistics and the ten most recently updated domains. `stale` counts domains that have been updated at some point, but not within the last 90 days.
+
+`Status: 200 OK`
+
+```json
+{
+  "generated_at": "2026-09-05T10:15:00Z",
+  "domain": "auth.example.org",
+  "database_engine": "sqlite3",
+  "domains": {
+    "total": 120,
+    "with_txt": 98,
+    "never_updated": 22,
+    "updated_last_24h": 5,
+    "updated_last_7d": 31,
+    "updated_last_30d": 80,
+    "updated_last_90d": 95,
+    "stale": 3
+  },
+  "recently_updated": [
+    {
+      "subdomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a",
+      "fulldomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a.auth.example.org",
+      "last_update": "2026-09-05T10:12:42Z"
+    }
+  ]
+}
+```
+
+Example:
+
+```bash
+$ curl -H "X-Admin-Key: $ACME_DNS_ADMIN_KEY" https://auth.example.org/admin/report
+```
 
 ## Self-hosted
 
@@ -269,6 +398,19 @@ corsorigins = [
 use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
+
+[admin]
+# enable the admin API (/admin/domains, /admin/domains/<subdomain>, /admin/domains/<subdomain>/txt, /admin/report)
+enabled = false
+# shared secret for the admin API, at least 32 characters, e.g. generated with: openssl rand -hex 32
+# send it in the "X-Admin-Key" header or as bearer token in the "Authorization" header
+api_key = ""
+# optional list of CIDR ranges that may access the admin API, an empty list allows all source addresses
+# the client address is taken from the connection, or from the header configured in the [api] section if use_header = true
+allow_from = [
+    "127.0.0.1/32",
+    "::1/128",
+]
 
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"

--- a/config.cfg
+++ b/config.cfg
@@ -54,6 +54,19 @@ use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
 
+[admin]
+# enable the admin API (/admin/domains, /admin/domains/<subdomain>, /admin/domains/<subdomain>/txt, /admin/report)
+enabled = false
+# shared secret for the admin API, at least 32 characters, e.g. generated with: openssl rand -hex 32
+# send it in the "X-Admin-Key" header or as bearer token in the "Authorization" header
+api_key = ""
+# optional list of CIDR ranges that may access the admin API, an empty list allows all source addresses
+# the client address is taken from the connection, or from the header configured in the [api] section if use_header = true
+allow_from = [
+    "127.0.0.1/32",
+    "::1/128",
+]
+
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"
 loglevel = "debug"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/hm-edu/acme-dns
 
-go 1.26.0
+go 1.27.0
 
 require (
+	codeberg.org/miekg/dns v0.6.109
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/caddyserver/certmagic v0.25.4
@@ -14,7 +15,6 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/libdns/libdns v1.1.1
 	github.com/mattn/go-sqlite3 v1.14.50
-	github.com/miekg/dns v1.1.73
 	github.com/rs/cors v1.11.1
 	github.com/sirupsen/logrus v1.10.2
 	github.com/stretchr/testify v1.12.1
@@ -38,6 +38,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mholt/acmez/v3 v3.1.6 // indirect
+	github.com/miekg/dns v1.1.73 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 code.pfad.fr/check v1.1.0 h1:GWvjdzhSEgHvEHe2uJujDcpmZoySKuHQNrZMfzfO0bE=
 code.pfad.fr/check v1.1.0/go.mod h1:NiUH13DtYsb7xp5wll0U4SXx7KhXQVCtRgdC96IPfoM=
+codeberg.org/miekg/dns v0.6.109 h1:B2lA6b6n/FuUTdECFU9HCunwxLRaR71d+UFV5EP44gg=
+codeberg.org/miekg/dns v0.6.109/go.mod h1:vbidSyLJl5JcDUL2LrXCUjRYSFa5tJweseQox0GOrTk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
@@ -142,8 +144,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
 golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/main.go
+++ b/main.go
@@ -109,9 +109,13 @@ func startHTTPAPI(errChan chan error, cfg *acmedns.DNSConfig, db acmedns.Databas
 	legolog.SetDefault(slog.New(slog.NewTextHandler(logwriter, nil)))
 
 	router := httprouter.New()
+	allowedMethods := []string{"GET", "POST"}
+	if cfg.Admin.Enabled {
+		allowedMethods = append(allowedMethods, "DELETE")
+	}
 	c := cors.New(cors.Options{
 		AllowedOrigins:     cfg.API.CorsOrigins,
-		AllowedMethods:     []string{"GET", "POST"},
+		AllowedMethods:     allowedMethods,
 		OptionsPassthrough: false,
 		Debug:              cfg.General.Debug,
 	})
@@ -126,6 +130,14 @@ func startHTTPAPI(errChan chan error, cfg *acmedns.DNSConfig, db acmedns.Databas
 	}
 	router.POST("/update", a.Auth(a.UpdatePost))
 	router.GET("/health", httpapi.HealthCheck)
+	if cfg.Admin.Enabled {
+		router.GET("/admin/domains", a.AdminAuth(a.AdminListDomains))
+		router.GET("/admin/domains/:subdomain", a.AdminAuth(a.AdminGetDomain))
+		router.GET("/admin/report", a.AdminAuth(a.AdminReport))
+		router.DELETE("/admin/domains/:subdomain", a.AdminAuth(a.AdminDeleteDomain))
+		router.POST("/admin/domains/:subdomain/txt", a.AdminAuth(a.AdminSetTXT))
+		log.WithFields(log.Fields{"allow_from": cfg.Admin.AllowFrom.ValidEntries()}).Info("Admin API enabled")
+	}
 
 	host := cfg.API.IP + ":" + cfg.API.Port
 

--- a/pkg/acmedns/config.go
+++ b/pkg/acmedns/config.go
@@ -2,17 +2,23 @@ package acmedns
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"unicode/utf8"
 
 	"github.com/BurntSushi/toml"
 	log "github.com/sirupsen/logrus"
 )
+
+// MinAdminAPIKeyLength is the minimum number of characters required for the admin API key
+const MinAdminAPIKeyLength = 32
 
 // DNSConfig holds the config structure
 type DNSConfig struct {
 	General   GeneralConfig
 	Database  DatabaseSettings
 	API       APIConfig
+	Admin     AdminConfig
 	Logconfig LogConfig
 }
 
@@ -38,17 +44,27 @@ type DatabaseSettings struct {
 type APIConfig struct {
 	Domain              string `toml:"api_domain"`
 	IP                  string
-	DisableRegistration bool     `toml:"disable_registration"`
-	AutocertPort        string   `toml:"autocert_port"`
-	Port                string   `toml:"port"`
+	DisableRegistration bool   `toml:"disable_registration"`
+	AutocertPort        string `toml:"autocert_port"`
+	Port                string `toml:"port"`
 	TLS                 string
-	TLSCertPrivkey      string   `toml:"tls_cert_privkey"`
-	TLSCertFullchain    string   `toml:"tls_cert_fullchain"`
-	ACMECacheDir        string   `toml:"acme_cache_dir"`
-	NotificationEmail   string   `toml:"notification_email"`
+	TLSCertPrivkey      string `toml:"tls_cert_privkey"`
+	TLSCertFullchain    string `toml:"tls_cert_fullchain"`
+	ACMECacheDir        string `toml:"acme_cache_dir"`
+	NotificationEmail   string `toml:"notification_email"`
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`
+}
+
+// AdminConfig holds the configuration of the admin API
+type AdminConfig struct {
+	// Enabled registers the /admin endpoints on the HTTP API listener
+	Enabled bool
+	// APIKey is the shared secret clients have to present to access the admin API
+	APIKey string `toml:"api_key"`
+	// AllowFrom optionally restricts admin API access to the listed CIDR ranges
+	AllowFrom CIDRSlice `toml:"allow_from"`
 }
 
 // LogConfig holds logging config
@@ -96,7 +112,28 @@ func PrepareConfig(conf DNSConfig) (DNSConfig, error) {
 		conf.API.ACMECacheDir = "api-certs"
 	}
 
+	if err := conf.Admin.Validate(); err != nil {
+		return conf, err
+	}
+
 	return conf, nil
+}
+
+// Validate checks that the admin API configuration is usable when the admin API is enabled
+func (a AdminConfig) Validate() error {
+	if !a.Enabled {
+		return nil
+	}
+	if a.APIKey == "" {
+		return errors.New("admin API is enabled but configuration option \"api_key\" is missing")
+	}
+	if utf8.RuneCountInString(a.APIKey) < MinAdminAPIKeyLength {
+		return fmt.Errorf("admin API key must be at least %d characters long", MinAdminAPIKeyLength)
+	}
+	if err := a.AllowFrom.IsValid(); err != nil {
+		return fmt.Errorf("invalid CIDR in admin configuration option \"allow_from\": %w", err)
+	}
+	return nil
 }
 
 // SetupLogging configures the logrus logger

--- a/pkg/acmedns/config_test.go
+++ b/pkg/acmedns/config_test.go
@@ -94,3 +94,75 @@ func TestGetIPListFromHeader(t *testing.T) {
 		}
 	}
 }
+
+func TestAdminConfigValidate(t *testing.T) {
+	longKey := "0123456789abcdef0123456789abcdef"
+	for i, test := range []struct {
+		cfg     AdminConfig
+		wantErr bool
+	}{
+		{AdminConfig{Enabled: false}, false},
+		{AdminConfig{Enabled: false, APIKey: "short"}, false},
+		{AdminConfig{Enabled: true}, true},
+		{AdminConfig{Enabled: true, APIKey: "short"}, true},
+		{AdminConfig{Enabled: true, APIKey: longKey}, false},
+		{AdminConfig{Enabled: true, APIKey: longKey, AllowFrom: CIDRSlice{"127.0.0.1/32", "[::1]/128"}}, false},
+		{AdminConfig{Enabled: true, APIKey: longKey, AllowFrom: CIDRSlice{"127.0.0.1"}}, true},
+		{AdminConfig{Enabled: true, APIKey: longKey, AllowFrom: CIDRSlice{"invalid"}}, true},
+	} {
+		err := test.cfg.Validate()
+		if (err != nil) != test.wantErr {
+			t.Errorf("Test %d: expected error=%v, got [%v]", i, test.wantErr, err)
+		}
+	}
+}
+
+func TestPrepareConfigAdmin(t *testing.T) {
+	base := DNSConfig{Database: DatabaseSettings{Engine: "sqlite3", Connection: ":memory:"}}
+
+	if _, err := PrepareConfig(base); err != nil {
+		t.Errorf("Expected no error for config without admin section, got [%v]", err)
+	}
+
+	bad := base
+	bad.Admin = AdminConfig{Enabled: true, APIKey: "tooshort"}
+	if _, err := PrepareConfig(bad); err == nil {
+		t.Errorf("Expected error for enabled admin API with short key, got none")
+	}
+
+	good := base
+	good.Admin = AdminConfig{Enabled: true, APIKey: "0123456789abcdef0123456789abcdef", AllowFrom: CIDRSlice{"10.0.0.0/8"}}
+	if _, err := PrepareConfig(good); err != nil {
+		t.Errorf("Expected no error for valid admin config, got [%v]", err)
+	}
+}
+
+func TestCIDRSliceAllows(t *testing.T) {
+	empty := CIDRSlice{}
+	if !empty.Allows("1.2.3.4") || !empty.AllowsAny([]string{}) || !empty.AllowsAny([]string{"whatever"}) {
+		t.Errorf("Empty allowlist must allow everything")
+	}
+	onlyInvalid := CIDRSlice{"invalid", "1.2.3.4"}
+	if !onlyInvalid.Allows("9.9.9.9") {
+		t.Errorf("Allowlist with only invalid entries must allow everything")
+	}
+	acl := CIDRSlice{"192.168.1.0/24", "[2001:db8::]/32", "invalid"}
+	for i, test := range []struct {
+		ips      []string
+		expected bool
+	}{
+		{[]string{"192.168.1.1"}, true},
+		{[]string{"192.168.2.1"}, false},
+		{[]string{"2001:db8:1::1"}, true},
+		{[]string{"2001:db9::1"}, false},
+		{[]string{"10.0.0.1", "192.168.1.200"}, true},
+		{[]string{"10.0.0.1", "10.0.0.2"}, false},
+		{[]string{}, false},
+		{[]string{""}, false},
+		{[]string{"not an ip"}, false},
+	} {
+		if got := acl.AllowsAny(test.ips); got != test.expected {
+			t.Errorf("Test %d: AllowsAny(%v) = %v, expected %v", i, test.ips, got, test.expected)
+		}
+	}
+}

--- a/pkg/acmedns/database.go
+++ b/pkg/acmedns/database.go
@@ -2,9 +2,13 @@ package acmedns
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/google/uuid"
 )
+
+// ErrDomainNotFound is returned when a subdomain is not registered
+var ErrDomainNotFound = errors.New("domain not found")
 
 // Database is the interface for acme-dns database operations
 type Database interface {
@@ -13,6 +17,16 @@ type Database interface {
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
 	Update(ACMETxtPost) error
+	// CountDomains returns the number of registered subdomains
+	CountDomains() (int, error)
+	// ListDomains returns registered subdomains ordered by subdomain, starting at offset and returning at most limit entries
+	ListDomains(limit int, offset int) ([]DomainInfo, error)
+	// GetDomain returns the details of a single registered subdomain, ErrDomainNotFound if it does not exist
+	GetDomain(string) (DomainInfo, error)
+	// GetDomainActivity returns a compact summary of every registered subdomain for reporting
+	GetDomainActivity() ([]DomainActivity, error)
+	// DeleteDomain removes a registered subdomain including its TXT records, ErrDomainNotFound if it does not exist
+	DeleteDomain(string) error
 	GetBackend() *sql.DB
 	SetBackend(*sql.DB)
 	Close()

--- a/pkg/acmedns/types.go
+++ b/pkg/acmedns/types.go
@@ -54,14 +54,16 @@ func (c *CIDRSlice) ValidEntries() []string {
 	return valid
 }
 
-// AllowedFrom checks if an IP address is within the allowed ranges
-func (a ACMETxt) AllowedFrom(ip string) bool {
-	remoteIP := net.ParseIP(ip)
-	if len(a.AllowFrom.ValidEntries()) == 0 {
+// Allows checks if an IP address is within the allowed ranges. An empty (or
+// completely invalid) slice allows every address.
+func (c *CIDRSlice) Allows(ip string) bool {
+	valid := c.ValidEntries()
+	if len(valid) == 0 {
 		return true
 	}
-	log.WithFields(log.Fields{"ip": remoteIP}).Debug("Checking if update is permitted from IP")
-	for _, v := range a.AllowFrom.ValidEntries() {
+	remoteIP := net.ParseIP(ip)
+	log.WithFields(log.Fields{"ip": remoteIP}).Debug("Checking if access is permitted from IP")
+	for _, v := range valid {
 		_, vnet, _ := net.ParseCIDR(v)
 		if vnet.Contains(remoteIP) {
 			return true
@@ -70,17 +72,27 @@ func (a ACMETxt) AllowedFrom(ip string) bool {
 	return false
 }
 
-// AllowedFromList checks if any IP in the list is within the allowed ranges
-func (a ACMETxt) AllowedFromList(ips []string) bool {
+// AllowsAny checks if any IP in the list is within the allowed ranges
+func (c *CIDRSlice) AllowsAny(ips []string) bool {
 	if len(ips) == 0 {
-		return a.AllowedFrom("")
+		return c.Allows("")
 	}
 	for _, v := range ips {
-		if a.AllowedFrom(v) {
+		if c.Allows(v) {
 			return true
 		}
 	}
 	return false
+}
+
+// AllowedFrom checks if an IP address is within the allowed ranges
+func (a ACMETxt) AllowedFrom(ip string) bool {
+	return a.AllowFrom.Allows(ip)
+}
+
+// AllowedFromList checks if any IP in the list is within the allowed ranges
+func (a ACMETxt) AllowedFromList(ips []string) bool {
+	return a.AllowFrom.AllowsAny(ips)
 }
 
 // NewACMETxt creates a new ACMETxt with a random password and UUID
@@ -91,4 +103,49 @@ func NewACMETxt() ACMETxt {
 	a.Password = password
 	a.Subdomain = uuid.New().String()
 	return a
+}
+
+// TXTRecord is one of the rolling TXT values stored for a subdomain
+type TXTRecord struct {
+	Value string
+	// LastUpdate is the unix timestamp of the last update, 0 if the value was never set
+	LastUpdate int64
+}
+
+// DomainInfo is the administrative view of a registered subdomain
+type DomainInfo struct {
+	Username  uuid.UUID
+	Subdomain string
+	AllowFrom CIDRSlice
+	TXT       []TXTRecord
+}
+
+// LastUpdate returns the unix timestamp of the most recent TXT update, 0 if the domain was never updated
+func (d DomainInfo) LastUpdate() int64 {
+	var last int64
+	for _, t := range d.TXT {
+		if t.LastUpdate > last {
+			last = t.LastUpdate
+		}
+	}
+	return last
+}
+
+// HasTXT reports whether at least one non-empty TXT value is stored for the domain
+func (d DomainInfo) HasTXT() bool {
+	for _, t := range d.TXT {
+		if t.Value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// DomainActivity is a compact per-subdomain summary used for reporting
+type DomainActivity struct {
+	Subdomain string
+	// LastUpdate is the unix timestamp of the most recent TXT update, 0 if never updated
+	LastUpdate int64
+	// HasTXT reports whether at least one non-empty TXT value is stored
+	HasTXT bool
 }

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -1,0 +1,339 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/hm-edu/acme-dns/pkg/acmedns"
+	"github.com/julienschmidt/httprouter"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// AdminDefaultLimit is the page size used by the domain listing when no limit is given
+	AdminDefaultLimit = 100
+	// AdminMaxLimit is the largest page size accepted by the domain listing
+	AdminMaxLimit = 1000
+	// AdminRecentUpdates is the number of most recently updated domains included in the report
+	AdminRecentUpdates = 10
+)
+
+// AdminTXTRecord is one stored TXT value of a domain
+type AdminTXTRecord struct {
+	Value      string     `json:"txt"`
+	LastUpdate *time.Time `json:"last_update"`
+}
+
+// AdminDomain is the admin API representation of a registered subdomain
+type AdminDomain struct {
+	Username   string           `json:"username"`
+	Subdomain  string           `json:"subdomain"`
+	Fulldomain string           `json:"fulldomain"`
+	Allowfrom  []string         `json:"allowfrom"`
+	TXTRecords []AdminTXTRecord `json:"txt_records"`
+	HasTXT     bool             `json:"has_txt"`
+	LastUpdate *time.Time       `json:"last_update"`
+}
+
+// AdminDomainList is the response body of the domain listing
+type AdminDomainList struct {
+	Total   int           `json:"total"`
+	Limit   int           `json:"limit"`
+	Offset  int           `json:"offset"`
+	Domains []AdminDomain `json:"domains"`
+}
+
+// AdminReportCounts holds the aggregated domain statistics of the report
+type AdminReportCounts struct {
+	Total          int `json:"total"`
+	WithTXT        int `json:"with_txt"`
+	NeverUpdated   int `json:"never_updated"`
+	UpdatedLast24h int `json:"updated_last_24h"`
+	UpdatedLast7d  int `json:"updated_last_7d"`
+	UpdatedLast30d int `json:"updated_last_30d"`
+	UpdatedLast90d int `json:"updated_last_90d"`
+	// Stale counts domains that have been updated at least once, but not within the last 90 days
+	Stale int `json:"stale"`
+}
+
+// AdminRecentUpdate is an entry of the recently updated domains list in the report
+type AdminRecentUpdate struct {
+	Subdomain  string    `json:"subdomain"`
+	Fulldomain string    `json:"fulldomain"`
+	LastUpdate time.Time `json:"last_update"`
+}
+
+// AdminReport is the response body of the report endpoint
+type AdminReport struct {
+	GeneratedAt     time.Time           `json:"generated_at"`
+	Domain          string              `json:"domain"`
+	DatabaseEngine  string              `json:"database_engine"`
+	Domains         AdminReportCounts   `json:"domains"`
+	RecentlyUpdated []AdminRecentUpdate `json:"recently_updated"`
+}
+
+// AdminListDomains handles GET /admin/domains
+func (a *API) AdminListDomains(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	limit, offset, err := parsePagination(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad_query_parameter")
+		return
+	}
+	total, err := a.DB.CountDomains()
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error while counting domains")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	infos, err := a.DB.ListDomains(limit, offset)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error while listing domains")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	resp := AdminDomainList{Total: total, Limit: limit, Offset: offset, Domains: make([]AdminDomain, 0, len(infos))}
+	for _, info := range infos {
+		resp.Domains = append(resp.Domains, a.adminDomain(info))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// AdminGetDomain handles GET /admin/domains/:subdomain
+func (a *API) AdminGetDomain(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	subdomain := p.ByName("subdomain")
+	if !acmedns.ValidSubdomain(subdomain) {
+		writeJSONError(w, http.StatusBadRequest, "bad_subdomain")
+		return
+	}
+	info, err := a.DB.GetDomain(subdomain)
+	if errors.Is(err, acmedns.ErrDomainNotFound) {
+		writeJSONError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error(), "subdomain": subdomain}).Error("Error while fetching domain")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, a.adminDomain(info))
+}
+
+// AdminReport handles GET /admin/report
+func (a *API) AdminReport(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	activity, err := a.DB.GetDomainActivity()
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error while gathering domain activity")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	counts, recent := BuildReport(activity, now, AdminRecentUpdates)
+	resp := AdminReport{
+		GeneratedAt:     now,
+		Domain:          a.Config.General.Domain,
+		DatabaseEngine:  a.Config.Database.Engine,
+		Domains:         counts,
+		RecentlyUpdated: make([]AdminRecentUpdate, 0, len(recent)),
+	}
+	for _, act := range recent {
+		resp.RecentlyUpdated = append(resp.RecentlyUpdated, AdminRecentUpdate{
+			Subdomain:  act.Subdomain,
+			Fulldomain: a.fulldomain(act.Subdomain),
+			LastUpdate: time.Unix(act.LastUpdate, 0).UTC(),
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// BuildReport aggregates the per-domain activity into report counters relative
+// to now and returns the recentLimit most recently updated domains.
+func BuildReport(activity []acmedns.DomainActivity, now time.Time, recentLimit int) (AdminReportCounts, []acmedns.DomainActivity) {
+	counts := AdminReportCounts{Total: len(activity)}
+	day := 24 * time.Hour
+	updated := make([]acmedns.DomainActivity, 0, len(activity))
+	for _, act := range activity {
+		if act.HasTXT {
+			counts.WithTXT++
+		}
+		if act.LastUpdate <= 0 {
+			counts.NeverUpdated++
+			continue
+		}
+		updated = append(updated, act)
+		age := now.Sub(time.Unix(act.LastUpdate, 0))
+		if age <= day {
+			counts.UpdatedLast24h++
+		}
+		if age <= 7*day {
+			counts.UpdatedLast7d++
+		}
+		if age <= 30*day {
+			counts.UpdatedLast30d++
+		}
+		if age <= 90*day {
+			counts.UpdatedLast90d++
+		} else {
+			counts.Stale++
+		}
+	}
+	sort.SliceStable(updated, func(i, j int) bool {
+		if updated[i].LastUpdate != updated[j].LastUpdate {
+			return updated[i].LastUpdate > updated[j].LastUpdate
+		}
+		return updated[i].Subdomain < updated[j].Subdomain
+	})
+	if recentLimit >= 0 && len(updated) > recentLimit {
+		updated = updated[:recentLimit]
+	}
+	return counts, updated
+}
+
+func (a *API) adminDomain(info acmedns.DomainInfo) AdminDomain {
+	resp := AdminDomain{
+		Username:   info.Username.String(),
+		Subdomain:  info.Subdomain,
+		Fulldomain: a.fulldomain(info.Subdomain),
+		Allowfrom:  info.AllowFrom.ValidEntries(),
+		TXTRecords: make([]AdminTXTRecord, 0, len(info.TXT)),
+		HasTXT:     info.HasTXT(),
+		LastUpdate: unixTime(info.LastUpdate()),
+	}
+	for _, t := range info.TXT {
+		resp.TXTRecords = append(resp.TXTRecords, AdminTXTRecord{Value: t.Value, LastUpdate: unixTime(t.LastUpdate)})
+	}
+	return resp
+}
+
+func (a *API) fulldomain(subdomain string) string {
+	return subdomain + "." + a.Config.General.Domain
+}
+
+func unixTime(ts int64) *time.Time {
+	if ts <= 0 {
+		return nil
+	}
+	t := time.Unix(ts, 0).UTC()
+	return &t
+}
+
+// parsePagination reads the limit and offset query parameters. Limits above
+// AdminMaxLimit are clamped, anything non-numeric, negative or a zero limit is
+// rejected.
+func parsePagination(r *http.Request) (int, int, error) {
+	limit := AdminDefaultLimit
+	offset := 0
+	q := r.URL.Query()
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return 0, 0, errors.New("invalid limit")
+		}
+		limit = n
+	}
+	if limit > AdminMaxLimit {
+		limit = AdminMaxLimit
+	}
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return 0, 0, errors.New("invalid offset")
+		}
+		offset = n
+	}
+	return limit, offset, nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Could not marshal JSON")
+		writeJSONError(w, http.StatusInternalServerError, "json_error")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(acmedns.JsonError(message))
+}
+
+// AdminSetTXTRequest is the request body for setting a TXT value via the admin API
+type AdminSetTXTRequest struct {
+	Value string `json:"txt"`
+}
+
+// maxAdminBodySize limits the size of request bodies accepted by the admin API
+const maxAdminBodySize = 64 * 1024
+
+// AdminDeleteDomain handles DELETE /admin/domains/:subdomain
+func (a *API) AdminDeleteDomain(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	subdomain := p.ByName("subdomain")
+	if !acmedns.ValidSubdomain(subdomain) {
+		writeJSONError(w, http.StatusBadRequest, "bad_subdomain")
+		return
+	}
+	err := a.DB.DeleteDomain(subdomain)
+	if errors.Is(err, acmedns.ErrDomainNotFound) {
+		writeJSONError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error(), "subdomain": subdomain}).Error("Error while deleting domain")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	log.WithFields(log.Fields{"subdomain": subdomain, "ips": a.requestIPs(r)}).Info("Domain deleted via admin API")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// AdminSetTXT handles POST /admin/domains/:subdomain/txt. It performs the same
+// rolling update of the two TXT values as the /update endpoint, but without
+// per-domain credentials.
+func (a *API) AdminSetTXT(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	subdomain := p.ByName("subdomain")
+	if !acmedns.ValidSubdomain(subdomain) {
+		writeJSONError(w, http.StatusBadRequest, "bad_subdomain")
+		return
+	}
+	var body AdminSetTXTRequest
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxAdminBodySize))
+	if err := dec.Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "malformed_json_payload")
+		return
+	}
+	if !acmedns.ValidTXT(body.Value) {
+		log.WithFields(log.Fields{"error": "txt", "subdomain": subdomain, "txt": body.Value}).Debug("Bad admin update data")
+		writeJSONError(w, http.StatusBadRequest, "bad_txt")
+		return
+	}
+	if _, err := a.DB.GetDomain(subdomain); err != nil {
+		if errors.Is(err, acmedns.ErrDomainNotFound) {
+			writeJSONError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		log.WithFields(log.Fields{"error": err.Error(), "subdomain": subdomain}).Error("Error while fetching domain")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	if err := a.DB.Update(acmedns.ACMETxtPost{Subdomain: subdomain, Value: body.Value}); err != nil {
+		log.WithFields(log.Fields{"error": err.Error(), "subdomain": subdomain}).Error("Error while trying to update record")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	log.WithFields(log.Fields{"subdomain": subdomain, "txt": body.Value, "ips": a.requestIPs(r)}).Info("TXT updated via admin API")
+	info, err := a.DB.GetDomain(subdomain)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error(), "subdomain": subdomain}).Error("Error while fetching domain")
+		writeJSONError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, a.adminDomain(info))
+}

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -1,0 +1,490 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/hm-edu/acme-dns/pkg/acmedns"
+	"github.com/julienschmidt/httprouter"
+)
+
+const testAdminKey = "0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func setupAdminRouter(useHeader bool, allowFrom acmedns.CIDRSlice) http.Handler {
+	cfg := acmedns.DNSConfig{
+		General: acmedns.GeneralConfig{
+			Domain: "auth.example.org",
+		},
+		Database: acmedns.DatabaseSettings{
+			Engine:     "sqlite3",
+			Connection: ":memory:",
+		},
+		API: acmedns.APIConfig{
+			UseHeader:  useHeader,
+			HeaderName: "X-Forwarded-For",
+		},
+		Admin: acmedns.AdminConfig{
+			Enabled:   true,
+			APIKey:    testAdminKey,
+			AllowFrom: allowFrom,
+		},
+	}
+	a := &API{Config: &cfg, DB: testDB}
+	router := httprouter.New()
+	router.GET("/admin/domains", a.AdminAuth(a.AdminListDomains))
+	router.GET("/admin/domains/:subdomain", a.AdminAuth(a.AdminGetDomain))
+	router.GET("/admin/report", a.AdminAuth(a.AdminReport))
+	return router
+}
+
+func adminExpect(t *testing.T, server *httptest.Server) *httpexpect.Expect {
+	return getExpect(t, server).Builder(func(req *httpexpect.Request) {
+		req.WithHeader(AdminKeyHeader, testAdminKey)
+	})
+}
+
+func TestAdminAuthKey(t *testing.T) {
+	server := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{}))
+	defer server.Close()
+	e := getExpect(t, server)
+
+	e.GET("/admin/domains").Expect().
+		Status(http.StatusUnauthorized).
+		JSON().Object().HasValue("error", "unauthorized")
+
+	e.GET("/admin/domains").WithHeader(AdminKeyHeader, "wrong-key").Expect().
+		Status(http.StatusUnauthorized).
+		JSON().Object().HasValue("error", "unauthorized")
+
+	e.GET("/admin/domains").WithHeader(AdminKeyHeader, testAdminKey+"x").Expect().
+		Status(http.StatusUnauthorized)
+
+	e.GET("/admin/domains").WithHeader("Authorization", "Basic "+testAdminKey).Expect().
+		Status(http.StatusUnauthorized)
+
+	e.GET("/admin/domains").WithHeader(AdminKeyHeader, testAdminKey).Expect().
+		Status(http.StatusOK).
+		JSON().Object().ContainsKey("domains")
+
+	e.GET("/admin/domains").WithHeader("Authorization", "Bearer "+testAdminKey).Expect().
+		Status(http.StatusOK)
+
+	e.GET("/admin/domains").WithHeader("Authorization", "bearer "+testAdminKey).Expect().
+		Status(http.StatusOK)
+
+	e.GET("/admin/report").Expect().Status(http.StatusUnauthorized)
+	e.GET("/admin/domains/whatever").Expect().Status(http.StatusUnauthorized)
+}
+
+func TestAdminAuthEmptyConfiguredKey(t *testing.T) {
+	cfg := acmedns.DNSConfig{Admin: acmedns.AdminConfig{Enabled: true}}
+	a := &API{Config: &cfg, DB: testDB}
+	if a.validAdminKey("") {
+		t.Errorf("Empty key must never be valid")
+	}
+	if a.validAdminKey("anything") {
+		t.Errorf("No key configured, nothing must be valid")
+	}
+}
+
+func TestAdminAuthIPHeader(t *testing.T) {
+	server := httptest.NewServer(setupAdminRouter(true, acmedns.CIDRSlice{"192.168.1.0/24", "2001:db8::/32"}))
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	for _, test := range []struct {
+		header string
+		status int
+	}{
+		{"", http.StatusForbidden},
+		{"10.0.0.1", http.StatusForbidden},
+		{"10.0.0.1, 10.0.0.2", http.StatusForbidden},
+		{"192.168.1.42", http.StatusOK},
+		{"10.0.0.1, 192.168.1.42", http.StatusOK},
+		{"2001:db8:1::1", http.StatusOK},
+		{"2001:db9::1", http.StatusForbidden},
+		{"not an ip", http.StatusForbidden},
+	} {
+		e.GET("/admin/report").WithHeader("X-Forwarded-For", test.header).Expect().Status(test.status)
+	}
+
+	// Denied by IP must not leak whether the key is valid
+	getExpect(t, server).GET("/admin/report").WithHeader("X-Forwarded-For", "10.0.0.1").Expect().
+		Status(http.StatusForbidden).
+		JSON().Object().HasValue("error", "forbidden")
+}
+
+func TestAdminAuthIPRemoteAddr(t *testing.T) {
+	allowed := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{"127.0.0.0/8", "::1/128"}))
+	defer allowed.Close()
+	adminExpect(t, allowed).GET("/admin/report").Expect().Status(http.StatusOK)
+
+	denied := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{"10.0.0.0/8"}))
+	defer denied.Close()
+	adminExpect(t, denied).GET("/admin/report").Expect().Status(http.StatusForbidden)
+
+	// Without header trust a spoofed header must not matter
+	adminExpect(t, denied).GET("/admin/report").WithHeader("X-Forwarded-For", "10.1.1.1").Expect().Status(http.StatusForbidden)
+
+	// Empty allowlist permits everyone
+	open := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{}))
+	defer open.Close()
+	adminExpect(t, open).GET("/admin/report").Expect().Status(http.StatusOK)
+}
+
+func TestAdminListDomains(t *testing.T) {
+	server := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{}))
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	newUser, err := testDB.Register(acmedns.CIDRSlice{"10.1.2.3/32"})
+	if err != nil {
+		t.Fatalf("Could not create new user, got error [%v]", err)
+	}
+	// A second registration guarantees at least two domains for the pagination checks
+	if _, err := testDB.Register(acmedns.CIDRSlice{}); err != nil {
+		t.Fatalf("Could not create second user, got error [%v]", err)
+	}
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newUser.Value = validTxtData
+	if err := testDB.Update(newUser.ACMETxtPost); err != nil {
+		t.Fatalf("Could not update record, got error [%v]", err)
+	}
+	total, _ := testDB.CountDomains()
+
+	resp := e.GET("/admin/domains").WithQuery("limit", AdminMaxLimit+1).Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+	resp.HasValue("total", total)
+	resp.HasValue("limit", AdminMaxLimit)
+	resp.HasValue("offset", 0)
+	domains := resp.Value("domains").Array()
+	domains.Length().IsEqual(total)
+
+	var found *httpexpect.Object
+	for _, v := range domains.Iter() {
+		obj := v.Object()
+		if obj.Value("subdomain").String().Raw() == newUser.Subdomain {
+			found = obj
+		}
+	}
+	if found == nil {
+		t.Fatalf("Registered subdomain %s not found in listing", newUser.Subdomain)
+	}
+	found.HasValue("username", newUser.Username.String())
+	found.HasValue("fulldomain", newUser.Subdomain+".auth.example.org")
+	found.HasValue("has_txt", true)
+	found.NotContainsKey("password")
+	found.Value("allowfrom").Array().ConsistsOf("10.1.2.3/32")
+	found.Value("last_update").NotNull()
+	records := found.Value("txt_records").Array()
+	records.Length().IsEqual(2)
+	records.Value(0).Object().HasValue("txt", validTxtData)
+	records.Value(0).Object().Value("last_update").NotNull()
+	records.Value(1).Object().HasValue("txt", "")
+	records.Value(1).Object().Value("last_update").IsNull()
+
+	// Pagination
+	page := e.GET("/admin/domains").WithQuery("limit", 1).WithQuery("offset", 1).Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+	page.HasValue("limit", 1)
+	page.HasValue("offset", 1)
+	page.Value("domains").Array().Length().IsEqual(1)
+
+	for _, test := range []struct {
+		limit  string
+		offset string
+	}{
+		{"abc", ""},
+		{"0", ""},
+		{"-1", ""},
+		{"", "abc"},
+		{"", "-1"},
+	} {
+		req := e.GET("/admin/domains")
+		if test.limit != "" {
+			req = req.WithQuery("limit", test.limit)
+		}
+		if test.offset != "" {
+			req = req.WithQuery("offset", test.offset)
+		}
+		req.Expect().Status(http.StatusBadRequest).JSON().Object().HasValue("error", "bad_query_parameter")
+	}
+}
+
+func TestAdminGetDomain(t *testing.T) {
+	server := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{}))
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	newUser, err := testDB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Could not create new user, got error [%v]", err)
+	}
+
+	resp := e.GET("/admin/domains/" + newUser.Subdomain).Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+	resp.HasValue("subdomain", newUser.Subdomain)
+	resp.HasValue("username", newUser.Username.String())
+	resp.HasValue("has_txt", false)
+	resp.Value("last_update").IsNull()
+	resp.Value("allowfrom").Array().IsEmpty()
+	resp.Value("txt_records").Array().Length().IsEqual(2)
+
+	e.GET("/admin/domains/a097455b-52cc-4569-90c8-7a4b97c6eba8").Expect().
+		Status(http.StatusNotFound).
+		JSON().Object().HasValue("error", "not_found")
+
+	e.GET("/admin/domains/not_a_valid.subdomain").Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().HasValue("error", "bad_subdomain")
+}
+
+func TestAdminReportEndpoint(t *testing.T) {
+	server := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{}))
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	newUser, err := testDB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Could not create new user, got error [%v]", err)
+	}
+	newUser.Value = "ccccccccccccccccccccccccccccccccccccccccccc"
+	if err := testDB.Update(newUser.ACMETxtPost); err != nil {
+		t.Fatalf("Could not update record, got error [%v]", err)
+	}
+	total, _ := testDB.CountDomains()
+
+	resp := e.GET("/admin/report").Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+	resp.HasValue("domain", "auth.example.org")
+	resp.HasValue("database_engine", "sqlite3")
+	resp.Value("generated_at").String().NotEmpty()
+	counts := resp.Value("domains").Object()
+	counts.HasValue("total", total)
+	counts.Value("with_txt").Number().Ge(1)
+	counts.Value("updated_last_24h").Number().Ge(1)
+	counts.Value("never_updated").Number().Ge(0)
+	recent := resp.Value("recently_updated").Array()
+	recent.Length().Ge(1)
+	recent.Value(0).Object().HasValue("subdomain", newUser.Subdomain)
+	recent.Value(0).Object().HasValue("fulldomain", newUser.Subdomain+".auth.example.org")
+}
+
+func TestAdminDBErrors(t *testing.T) {
+	server := httptest.NewServer(setupAdminRouter(false, acmedns.CIDRSlice{}))
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	oldDb := testDB.GetBackend()
+	db, mock, _ := sqlmock.New()
+	testDB.SetBackend(db)
+	defer func(db *sql.DB) {
+		_ = db.Close()
+	}(db)
+	defer testDB.SetBackend(oldDb)
+
+	mock.ExpectQuery("SELECT COUNT").WillReturnError(errors.New("error"))
+	e.GET("/admin/domains").Expect().Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT r.Username").WillReturnError(errors.New("error"))
+	e.GET("/admin/domains").Expect().Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+
+	mock.ExpectQuery("SELECT r.Username").WillReturnError(errors.New("error"))
+	e.GET("/admin/domains/a097455b-52cc-4569-90c8-7a4b97c6eba8").Expect().Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+
+	mock.ExpectQuery("SELECT r.Subdomain").WillReturnError(errors.New("error"))
+	e.GET("/admin/report").Expect().Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+}
+
+func TestBuildReport(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	ts := func(age time.Duration) int64 { return now.Add(-age).Unix() }
+	day := 24 * time.Hour
+	activity := []acmedns.DomainActivity{
+		{Subdomain: "never", LastUpdate: 0, HasTXT: false},
+		{Subdomain: "fresh", LastUpdate: ts(1 * time.Hour), HasTXT: true},
+		{Subdomain: "week", LastUpdate: ts(3 * day), HasTXT: true},
+		{Subdomain: "month", LastUpdate: ts(20 * day), HasTXT: true},
+		{Subdomain: "quarter", LastUpdate: ts(60 * day), HasTXT: true},
+		{Subdomain: "stale", LastUpdate: ts(200 * day), HasTXT: true},
+		{Subdomain: "stale-empty", LastUpdate: ts(400 * day), HasTXT: false},
+	}
+
+	counts, recent := BuildReport(activity, now, 3)
+	expected := AdminReportCounts{
+		Total:          7,
+		WithTXT:        5,
+		NeverUpdated:   1,
+		UpdatedLast24h: 1,
+		UpdatedLast7d:  2,
+		UpdatedLast30d: 3,
+		UpdatedLast90d: 4,
+		Stale:          2,
+	}
+	if counts != expected {
+		t.Errorf("Unexpected counts: got %+v, expected %+v", counts, expected)
+	}
+	if len(recent) != 3 {
+		t.Fatalf("Expected 3 recent entries, got %d", len(recent))
+	}
+	for i, want := range []string{"fresh", "week", "month"} {
+		if recent[i].Subdomain != want {
+			t.Errorf("Recent entry %d: expected %s, got %s", i, want, recent[i].Subdomain)
+		}
+	}
+
+	_, all := BuildReport(activity, now, -1)
+	if len(all) != 6 {
+		t.Errorf("Expected all 6 updated entries with negative limit, got %d", len(all))
+	}
+	counts, none := BuildReport(nil, now, 5)
+	if counts.Total != 0 || len(none) != 0 {
+		t.Errorf("Expected empty report for no activity, got %+v / %d", counts, len(none))
+	}
+}
+
+func setupAdminWriteRouter() http.Handler {
+	cfg := acmedns.DNSConfig{
+		General:  acmedns.GeneralConfig{Domain: "auth.example.org"},
+		Database: acmedns.DatabaseSettings{Engine: "sqlite3", Connection: ":memory:"},
+		API:      acmedns.APIConfig{HeaderName: "X-Forwarded-For"},
+		Admin:    acmedns.AdminConfig{Enabled: true, APIKey: testAdminKey},
+	}
+	a := &API{Config: &cfg, DB: testDB}
+	router := httprouter.New()
+	router.GET("/admin/domains/:subdomain", a.AdminAuth(a.AdminGetDomain))
+	router.DELETE("/admin/domains/:subdomain", a.AdminAuth(a.AdminDeleteDomain))
+	router.POST("/admin/domains/:subdomain/txt", a.AdminAuth(a.AdminSetTXT))
+	return router
+}
+
+func TestAdminDeleteDomain(t *testing.T) {
+	server := httptest.NewServer(setupAdminWriteRouter())
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	newUser, err := testDB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Could not create new user, got error [%v]", err)
+	}
+
+	// Authentication is enforced on write endpoints as well
+	getExpect(t, server).DELETE("/admin/domains/" + newUser.Subdomain).Expect().Status(http.StatusUnauthorized)
+	if _, err := testDB.GetDomain(newUser.Subdomain); err != nil {
+		t.Fatalf("Domain must still exist after unauthorized delete, got [%v]", err)
+	}
+
+	e.DELETE("/admin/domains/" + newUser.Subdomain).Expect().Status(http.StatusNoContent).NoContent()
+	e.GET("/admin/domains/" + newUser.Subdomain).Expect().Status(http.StatusNotFound)
+	e.DELETE("/admin/domains/"+newUser.Subdomain).Expect().
+		Status(http.StatusNotFound).
+		JSON().Object().HasValue("error", "not_found")
+	e.DELETE("/admin/domains/not_valid.subdomain").Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().HasValue("error", "bad_subdomain")
+}
+
+func TestAdminSetTXT(t *testing.T) {
+	server := httptest.NewServer(setupAdminWriteRouter())
+	defer server.Close()
+	e := adminExpect(t, server)
+
+	newUser, err := testDB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Could not create new user, got error [%v]", err)
+	}
+	txt1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	txt2 := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	txt3 := "ccccccccccccccccccccccccccccccccccccccccccc"
+	path := "/admin/domains/" + newUser.Subdomain + "/txt"
+
+	getExpect(t, server).POST(path).WithJSON(map[string]string{"txt": txt1}).Expect().Status(http.StatusUnauthorized)
+
+	resp := e.POST(path).WithJSON(map[string]string{"txt": txt1}).Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+	resp.HasValue("subdomain", newUser.Subdomain)
+	resp.HasValue("has_txt", true)
+	resp.Value("txt_records").Array().Value(0).Object().HasValue("txt", txt1)
+
+	// Second value fills the second slot, third value rolls over the oldest one
+	e.POST(path).WithJSON(map[string]string{"txt": txt2}).Expect().Status(http.StatusOK)
+	e.POST(path).WithJSON(map[string]string{"txt": txt3}).Expect().Status(http.StatusOK)
+	served, err := testDB.GetTXTForDomain(newUser.Subdomain)
+	if err != nil {
+		t.Fatalf("GetTXTForDomain failed: [%v]", err)
+	}
+	if len(served) != 2 {
+		t.Fatalf("Expected 2 TXT values, got %v", served)
+	}
+	for _, v := range served {
+		if v != txt2 && v != txt3 {
+			t.Errorf("Unexpected TXT value %q served, expected %q and %q", v, txt2, txt3)
+		}
+	}
+
+	e.POST(path).WithJSON(map[string]string{"txt": "tooshort"}).Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().HasValue("error", "bad_txt")
+	e.POST(path).WithBytes([]byte("{not json")).Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().HasValue("error", "malformed_json_payload")
+	e.POST(path).WithJSON(map[string]int{"txt": 1234}).Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().HasValue("error", "malformed_json_payload")
+	e.POST("/admin/domains/a097455b-52cc-4569-90c8-7a4b97c6eba8/txt").WithJSON(map[string]string{"txt": txt1}).Expect().
+		Status(http.StatusNotFound).
+		JSON().Object().HasValue("error", "not_found")
+	e.POST("/admin/domains/not_valid.subdomain/txt").WithJSON(map[string]string{"txt": txt1}).Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().HasValue("error", "bad_subdomain")
+}
+
+func TestAdminWriteDBErrors(t *testing.T) {
+	server := httptest.NewServer(setupAdminWriteRouter())
+	defer server.Close()
+	e := adminExpect(t, server)
+	txt := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	sub := "a097455b-52cc-4569-90c8-7a4b97c6eba8"
+	domainRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"Username", "Subdomain", "AllowFrom", "Value", "LastUpdate"}).
+			AddRow("c36f50e8-4632-44f0-83fe-e070fef28a10", sub, "[]", "", 0)
+	}
+
+	oldDb := testDB.GetBackend()
+	db, mock, _ := sqlmock.New()
+	testDB.SetBackend(db)
+	defer func(db *sql.DB) {
+		_ = db.Close()
+	}(db)
+	defer testDB.SetBackend(oldDb)
+
+	mock.ExpectBegin().WillReturnError(errors.New("error"))
+	e.DELETE("/admin/domains/"+sub).Expect().Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+
+	mock.ExpectQuery("SELECT r.Username").WillReturnError(errors.New("error"))
+	e.POST("/admin/domains/"+sub+"/txt").WithJSON(map[string]string{"txt": txt}).Expect().
+		Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+
+	mock.ExpectQuery("SELECT r.Username").WillReturnRows(domainRows())
+	mock.ExpectPrepare("UPDATE txt").WillReturnError(errors.New("error"))
+	e.POST("/admin/domains/"+sub+"/txt").WithJSON(map[string]string{"txt": txt}).Expect().
+		Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+
+	mock.ExpectQuery("SELECT r.Username").WillReturnRows(domainRows())
+	mock.ExpectPrepare("UPDATE txt").ExpectExec().WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT r.Username").WillReturnError(errors.New("error"))
+	e.POST("/admin/domains/"+sub+"/txt").WithJSON(map[string]string{"txt": txt}).Expect().
+		Status(http.StatusInternalServerError).JSON().Object().HasValue("error", "db_error")
+}

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/hm-edu/acme-dns/pkg/acmedns"
 	"github.com/julienschmidt/httprouter"
@@ -16,6 +18,10 @@ type contextKey int
 
 // ACMETxtKey is the context key for ACMETxt values
 const ACMETxtKey contextKey = 0
+
+// AdminKeyHeader is the header carrying the admin API key. Alternatively the
+// key can be sent as a bearer token in the Authorization header.
+const AdminKeyHeader = "X-Admin-Key"
 
 // Auth is the authentication middleware for update requests
 func (a *API) Auth(update httprouter.Handle) httprouter.Handle {
@@ -54,6 +60,44 @@ func (a *API) Auth(update httprouter.Handle) httprouter.Handle {
 	}
 }
 
+// AdminAuth is the authentication middleware for the admin API. The optional
+// source IP allowlist is checked first, then the API key.
+func (a *API) AdminAuth(next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		ips := a.requestIPs(r)
+		if !a.Config.Admin.AllowFrom.AllowsAny(ips) {
+			log.WithFields(log.Fields{"error": "ip_unauthorized", "ips": ips, "path": r.URL.Path}).Warn("Admin API access not allowed from IP")
+			writeJSONError(w, http.StatusForbidden, "forbidden")
+			return
+		}
+		if !a.validAdminKey(adminKeyFromRequest(r)) {
+			log.WithFields(log.Fields{"error": "invalid_api_key", "ips": ips, "path": r.URL.Path}).Warn("Admin API access with invalid API key")
+			writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		next(w, r, p)
+	}
+}
+
+func adminKeyFromRequest(r *http.Request) string {
+	if key := r.Header.Get(AdminKeyHeader); key != "" {
+		return key
+	}
+	auth := r.Header.Get("Authorization")
+	if len(auth) > 7 && strings.EqualFold(auth[:7], "Bearer ") {
+		return strings.TrimSpace(auth[7:])
+	}
+	return ""
+}
+
+func (a *API) validAdminKey(key string) bool {
+	expected := a.Config.Admin.APIKey
+	if key == "" || expected == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(key), []byte(expected)) == 1
+}
+
 func (a *API) getUserFromRequest(r *http.Request) (acmedns.ACMETxt, error) {
 	uname := r.Header.Get("X-Api-User")
 	passwd := r.Header.Get("X-Api-Key")
@@ -77,15 +121,20 @@ func (a *API) getUserFromRequest(r *http.Request) (acmedns.ACMETxt, error) {
 	return acmedns.ACMETxt{}, fmt.Errorf("invalid key for user %s", uname)
 }
 
-func (a *API) updateAllowedFromIP(r *http.Request, user acmedns.ACMETxt) bool {
+// requestIPs returns the client IP addresses of a request, either taken from
+// the configured header or from the remote address of the connection.
+func (a *API) requestIPs(r *http.Request) []string {
 	if a.Config.API.UseHeader {
-		ips := acmedns.GetIPListFromHeader(r.Header.Get(a.Config.API.HeaderName))
-		return user.AllowedFromList(ips)
+		return acmedns.GetIPListFromHeader(r.Header.Get(a.Config.API.HeaderName))
 	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err.Error(), "remoteaddr": r.RemoteAddr}).Error("Error while parsing remote address")
-		host = ""
+		return []string{}
 	}
-	return user.AllowedFrom(host)
+	return []string{host}
+}
+
+func (a *API) updateAllowedFromIP(r *http.Request, user acmedns.ACMETxt) bool {
+	return user.AllowedFromList(a.requestIPs(r))
 }

--- a/pkg/database/admin.go
+++ b/pkg/database/admin.go
@@ -1,0 +1,193 @@
+package database
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/hm-edu/acme-dns/pkg/acmedns"
+	log "github.com/sirupsen/logrus"
+)
+
+var listDomainsSQL = `
+	SELECT r.Username, r.Subdomain, r.AllowFrom, t.Value, t.LastUpdate
+	FROM (SELECT Username, Subdomain, AllowFrom FROM records ORDER BY Subdomain LIMIT $1 OFFSET $2) r
+	LEFT JOIN txt t ON t.Subdomain = r.Subdomain
+	ORDER BY r.Subdomain, t.LastUpdate DESC, t.Value`
+
+var getDomainSQL = `
+	SELECT r.Username, r.Subdomain, r.AllowFrom, t.Value, t.LastUpdate
+	FROM records r
+	LEFT JOIN txt t ON t.Subdomain = r.Subdomain
+	WHERE r.Subdomain = $1
+	ORDER BY t.LastUpdate DESC, t.Value`
+
+var domainActivitySQL = `
+	SELECT r.Subdomain,
+		MAX(COALESCE(t.LastUpdate, 0)),
+		MAX(CASE WHEN COALESCE(t.Value, '') <> '' THEN 1 ELSE 0 END)
+	FROM records r
+	LEFT JOIN txt t ON t.Subdomain = r.Subdomain
+	GROUP BY r.Subdomain
+	ORDER BY r.Subdomain`
+
+// CountDomains returns the number of registered subdomains
+func (d *AcmeDB) CountDomains() (int, error) {
+	d.Lock()
+	defer d.Unlock()
+	var count int
+	err := d.DB.QueryRow("SELECT COUNT(*) FROM records").Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// ListDomains returns registered subdomains ordered by subdomain, starting at
+// offset and returning at most limit entries
+func (d *AcmeDB) ListDomains(limit int, offset int) ([]acmedns.DomainInfo, error) {
+	d.Lock()
+	defer d.Unlock()
+	return d.queryDomainInfos(listDomainsSQL, limit, offset)
+}
+
+// GetDomain returns the details of a single registered subdomain
+func (d *AcmeDB) GetDomain(subdomain string) (acmedns.DomainInfo, error) {
+	d.Lock()
+	defer d.Unlock()
+	infos, err := d.queryDomainInfos(getDomainSQL, acmedns.SanitizeString(subdomain))
+	if err != nil {
+		return acmedns.DomainInfo{}, err
+	}
+	if len(infos) == 0 {
+		return acmedns.DomainInfo{}, acmedns.ErrDomainNotFound
+	}
+	return infos[0], nil
+}
+
+// GetDomainActivity returns a compact summary of every registered subdomain
+func (d *AcmeDB) GetDomainActivity() ([]acmedns.DomainActivity, error) {
+	d.Lock()
+	defer d.Unlock()
+	rows, err := d.DB.Query(domainActivitySQL)
+	if err != nil {
+		return nil, err
+	}
+	defer func(rows *sql.Rows) {
+		_ = rows.Close()
+	}(rows)
+
+	result := []acmedns.DomainActivity{}
+	for rows.Next() {
+		var subdomain string
+		var lastUpdate sql.NullInt64
+		var hasTXT sql.NullInt64
+		if err := rows.Scan(&subdomain, &lastUpdate, &hasTXT); err != nil {
+			log.WithFields(log.Fields{"error": err.Error()}).Error("Row scan error")
+			return nil, err
+		}
+		result = append(result, acmedns.DomainActivity{
+			Subdomain:  subdomain,
+			LastUpdate: lastUpdate.Int64,
+			HasTXT:     hasTXT.Int64 > 0,
+		})
+	}
+	return result, rows.Err()
+}
+
+// queryDomainInfos runs a query selecting Username, Subdomain, AllowFrom, Value
+// and LastUpdate and folds
+// the (up to two) txt rows per subdomain into a single DomainInfo. Rows have to
+// be ordered by subdomain.
+func (d *AcmeDB) queryDomainInfos(query string, args ...interface{}) ([]acmedns.DomainInfo, error) {
+	if d.engine == "sqlite3" {
+		query = getSQLiteStmt(query)
+	}
+	rows, err := d.DB.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func(rows *sql.Rows) {
+		_ = rows.Close()
+	}(rows)
+
+	result := []acmedns.DomainInfo{}
+	for rows.Next() {
+		var username, subdomain string
+		var allowFrom, value sql.NullString
+		var lastUpdate sql.NullInt64
+		if err := rows.Scan(&username, &subdomain, &allowFrom, &value, &lastUpdate); err != nil {
+			log.WithFields(log.Fields{"error": err.Error()}).Error("Row scan error")
+			return nil, err
+		}
+		if len(result) == 0 || result[len(result)-1].Subdomain != subdomain {
+			uid, err := uuid.Parse(username)
+			if err != nil {
+				log.WithFields(log.Fields{"error": err.Error(), "username": username}).Error("Invalid username in database")
+				return nil, err
+			}
+			result = append(result, acmedns.DomainInfo{
+				Username:  uid,
+				Subdomain: subdomain,
+				AllowFrom: parseAllowFrom(allowFrom.String),
+				TXT:       []acmedns.TXTRecord{},
+			})
+		}
+		if value.Valid {
+			current := &result[len(result)-1]
+			current.TXT = append(current.TXT, acmedns.TXTRecord{Value: value.String, LastUpdate: lastUpdate.Int64})
+		}
+	}
+	return result, rows.Err()
+}
+
+func parseAllowFrom(raw string) acmedns.CIDRSlice {
+	cslice := acmedns.CIDRSlice{}
+	if raw == "" {
+		return cslice
+	}
+	if err := json.Unmarshal([]byte(raw), &cslice); err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("JSON unmarshall error")
+		return acmedns.CIDRSlice{}
+	}
+	return cslice
+}
+
+// DeleteDomain removes a registered subdomain and its TXT records
+func (d *AcmeDB) DeleteDomain(subdomain string) (err error) {
+	d.Lock()
+	defer d.Unlock()
+	subdomain = acmedns.SanitizeString(subdomain)
+	tx, err := d.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	delRecord := "DELETE FROM records WHERE Subdomain=$1"
+	delTXT := "DELETE FROM txt WHERE Subdomain=$1"
+	if d.engine == "sqlite3" {
+		delRecord = getSQLiteStmt(delRecord)
+		delTXT = getSQLiteStmt(delTXT)
+	}
+	res, err := tx.Exec(delRecord, subdomain)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		err = acmedns.ErrDomainNotFound
+		return err
+	}
+	if _, err = tx.Exec(delTXT, subdomain); err != nil {
+		return err
+	}
+	err = tx.Commit()
+	return err
+}

--- a/pkg/database/admin_test.go
+++ b/pkg/database/admin_test.go
@@ -1,0 +1,329 @@
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hm-edu/acme-dns/pkg/acmedns"
+)
+
+func TestCountDomains(t *testing.T) {
+	before, err := DB.CountDomains()
+	if err != nil {
+		t.Fatalf("CountDomains failed: [%v]", err)
+	}
+	if _, err := DB.Register(acmedns.CIDRSlice{}); err != nil {
+		t.Fatalf("Registration failed, got error [%v]", err)
+	}
+	after, err := DB.CountDomains()
+	if err != nil {
+		t.Fatalf("CountDomains failed: [%v]", err)
+	}
+	if after != before+1 {
+		t.Errorf("Expected count to grow from %d to %d, got %d", before, before+1, after)
+	}
+}
+
+func TestGetDomain(t *testing.T) {
+	reg, err := DB.Register(acmedns.CIDRSlice{"192.168.1.0/24", "invalid", "[::1]/128"})
+	if err != nil {
+		t.Fatalf("Registration failed, got error [%v]", err)
+	}
+
+	info, err := DB.GetDomain(reg.Subdomain)
+	if err != nil {
+		t.Fatalf("GetDomain failed: [%v]", err)
+	}
+	if info.Username != reg.Username {
+		t.Errorf("Expected username %s, got %s", reg.Username, info.Username)
+	}
+	if info.Subdomain != reg.Subdomain {
+		t.Errorf("Expected subdomain %s, got %s", reg.Subdomain, info.Subdomain)
+	}
+	if len(info.AllowFrom) != 2 {
+		t.Errorf("Expected 2 allowfrom entries, got %v", info.AllowFrom)
+	}
+	if len(info.TXT) != 2 {
+		t.Fatalf("Expected 2 TXT records for a fresh registration, got %d", len(info.TXT))
+	}
+	if info.HasTXT() {
+		t.Errorf("Fresh registration should not have TXT values")
+	}
+	if info.LastUpdate() != 0 {
+		t.Errorf("Fresh registration should never have been updated, got %d", info.LastUpdate())
+	}
+
+	validTXT := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	before := time.Now().Unix()
+	reg.Value = validTXT
+	if err := DB.Update(reg.ACMETxtPost); err != nil {
+		t.Fatalf("Update failed: [%v]", err)
+	}
+
+	info, err = DB.GetDomain(reg.Subdomain)
+	if err != nil {
+		t.Fatalf("GetDomain failed: [%v]", err)
+	}
+	if !info.HasTXT() {
+		t.Errorf("Expected TXT value after update")
+	}
+	if info.LastUpdate() < before {
+		t.Errorf("Expected last update >= %d, got %d", before, info.LastUpdate())
+	}
+	// Records are ordered by LastUpdate descending, so the updated value comes first
+	if info.TXT[0].Value != validTXT {
+		t.Errorf("Expected first TXT record to be %q, got %q", validTXT, info.TXT[0].Value)
+	}
+	if info.TXT[1].Value != "" || info.TXT[1].LastUpdate != 0 {
+		t.Errorf("Expected second TXT record to be untouched, got %+v", info.TXT[1])
+	}
+
+	_, err = DB.GetDomain("does-not-exist")
+	if !errors.Is(err, acmedns.ErrDomainNotFound) {
+		t.Errorf("Expected ErrDomainNotFound, got [%v]", err)
+	}
+}
+
+func TestListDomains(t *testing.T) {
+	for i := 0; i < 3; i++ {
+		if _, err := DB.Register(acmedns.CIDRSlice{}); err != nil {
+			t.Fatalf("Registration failed, got error [%v]", err)
+		}
+	}
+	total, err := DB.CountDomains()
+	if err != nil {
+		t.Fatalf("CountDomains failed: [%v]", err)
+	}
+
+	all, err := DB.ListDomains(total+10, 0)
+	if err != nil {
+		t.Fatalf("ListDomains failed: [%v]", err)
+	}
+	if len(all) != total {
+		t.Fatalf("Expected %d domains, got %d", total, len(all))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1].Subdomain >= all[i].Subdomain {
+			t.Errorf("Expected domains to be sorted by subdomain, got %s before %s", all[i-1].Subdomain, all[i].Subdomain)
+		}
+	}
+	for _, info := range all {
+		if len(info.TXT) != 2 {
+			t.Errorf("Expected 2 TXT records for %s, got %d", info.Subdomain, len(info.TXT))
+		}
+	}
+
+	page, err := DB.ListDomains(2, 1)
+	if err != nil {
+		t.Fatalf("ListDomains failed: [%v]", err)
+	}
+	if len(page) != 2 {
+		t.Fatalf("Expected page of 2 domains, got %d", len(page))
+	}
+	if page[0].Subdomain != all[1].Subdomain || page[1].Subdomain != all[2].Subdomain {
+		t.Errorf("Unexpected page content: got %s, %s expected %s, %s", page[0].Subdomain, page[1].Subdomain, all[1].Subdomain, all[2].Subdomain)
+	}
+
+	empty, err := DB.ListDomains(10, total+100)
+	if err != nil {
+		t.Fatalf("ListDomains failed: [%v]", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("Expected empty page, got %d entries", len(empty))
+	}
+}
+
+func TestGetDomainActivity(t *testing.T) {
+	updated, err := DB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Registration failed, got error [%v]", err)
+	}
+	untouched, err := DB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Registration failed, got error [%v]", err)
+	}
+	updated.Value = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if err := DB.Update(updated.ACMETxtPost); err != nil {
+		t.Fatalf("Update failed: [%v]", err)
+	}
+
+	activity, err := DB.GetDomainActivity()
+	if err != nil {
+		t.Fatalf("GetDomainActivity failed: [%v]", err)
+	}
+	total, _ := DB.CountDomains()
+	if len(activity) != total {
+		t.Errorf("Expected %d activity entries, got %d", total, len(activity))
+	}
+	var foundUpdated, foundUntouched bool
+	for _, act := range activity {
+		switch act.Subdomain {
+		case updated.Subdomain:
+			foundUpdated = true
+			if !act.HasTXT || act.LastUpdate == 0 {
+				t.Errorf("Expected updated domain to have TXT and last update, got %+v", act)
+			}
+		case untouched.Subdomain:
+			foundUntouched = true
+			if act.HasTXT || act.LastUpdate != 0 {
+				t.Errorf("Expected untouched domain to have no TXT and no last update, got %+v", act)
+			}
+		}
+	}
+	if !foundUpdated || !foundUntouched {
+		t.Errorf("Expected both registered domains in activity, found updated=%v untouched=%v", foundUpdated, foundUntouched)
+	}
+}
+
+func TestAdminQueryErrors(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Could not create sqlmock: %v", err)
+	}
+	defer func(db *sql.DB) {
+		_ = db.Close()
+	}(mockDB)
+	oldDb := DB.GetBackend()
+	DB.SetBackend(mockDB)
+	defer DB.SetBackend(oldDb)
+
+	mock.ExpectQuery("SELECT COUNT").WillReturnError(errors.New("count error"))
+	if _, err := DB.CountDomains(); err == nil {
+		t.Errorf("Expected error from CountDomains, got none")
+	}
+
+	mock.ExpectQuery("SELECT r.Username").WillReturnError(errors.New("list error"))
+	if _, err := DB.ListDomains(10, 0); err == nil {
+		t.Errorf("Expected error from ListDomains, got none")
+	}
+
+	mock.ExpectQuery("SELECT r.Username").WillReturnError(errors.New("get error"))
+	if _, err := DB.GetDomain("whatever"); err == nil {
+		t.Errorf("Expected error from GetDomain, got none")
+	}
+
+	mock.ExpectQuery("SELECT r.Subdomain").WillReturnError(errors.New("activity error"))
+	if _, err := DB.GetDomainActivity(); err == nil {
+		t.Errorf("Expected error from GetDomainActivity, got none")
+	}
+
+	// Scan errors: wrong column count and invalid username
+	mock.ExpectQuery("SELECT r.Username").WillReturnRows(sqlmock.NewRows([]string{"Only one"}).AddRow("value"))
+	if _, err := DB.ListDomains(10, 0); err == nil {
+		t.Errorf("Expected scan error from ListDomains, got none")
+	}
+	mock.ExpectQuery("SELECT r.Username").WillReturnRows(
+		sqlmock.NewRows([]string{"Username", "Subdomain", "AllowFrom", "Value", "LastUpdate"}).
+			AddRow("not-a-uuid", "sub", "[]", "", 0))
+	if _, err := DB.ListDomains(10, 0); err == nil {
+		t.Errorf("Expected invalid username error from ListDomains, got none")
+	}
+	mock.ExpectQuery("SELECT r.Subdomain").WillReturnRows(sqlmock.NewRows([]string{"Only one"}).AddRow("value"))
+	if _, err := DB.GetDomainActivity(); err == nil {
+		t.Errorf("Expected scan error from GetDomainActivity, got none")
+	}
+
+	// Rows with NULL txt columns and broken AllowFrom JSON are tolerated
+	mock.ExpectQuery("SELECT r.Username").WillReturnRows(
+		sqlmock.NewRows([]string{"Username", "Subdomain", "AllowFrom", "Value", "LastUpdate"}).
+			AddRow("a097455b-52cc-4569-90c8-7a4b97c6eba8", "sub", "not json", nil, nil))
+	infos, err := DB.ListDomains(10, 0)
+	if err != nil {
+		t.Fatalf("Unexpected error from ListDomains: %v", err)
+	}
+	if len(infos) != 1 || len(infos[0].TXT) != 0 || len(infos[0].AllowFrom) != 0 {
+		t.Errorf("Unexpected result for NULL txt row: %+v", infos)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestDeleteDomain(t *testing.T) {
+	reg, err := DB.Register(acmedns.CIDRSlice{})
+	if err != nil {
+		t.Fatalf("Registration failed, got error [%v]", err)
+	}
+	reg.Value = "ddddddddddddddddddddddddddddddddddddddddddd"
+	if err := DB.Update(reg.ACMETxtPost); err != nil {
+		t.Fatalf("Update failed: [%v]", err)
+	}
+	before, _ := DB.CountDomains()
+
+	if err := DB.DeleteDomain(reg.Subdomain); err != nil {
+		t.Fatalf("DeleteDomain failed: [%v]", err)
+	}
+	after, _ := DB.CountDomains()
+	if after != before-1 {
+		t.Errorf("Expected count to drop from %d to %d, got %d", before, before-1, after)
+	}
+	if _, err := DB.GetDomain(reg.Subdomain); !errors.Is(err, acmedns.ErrDomainNotFound) {
+		t.Errorf("Expected ErrDomainNotFound after delete, got [%v]", err)
+	}
+	if _, err := DB.GetByUsername(reg.Username); err == nil {
+		t.Errorf("Expected user lookup to fail after delete")
+	}
+	txts, err := DB.GetTXTForDomain(reg.Subdomain)
+	if err != nil {
+		t.Fatalf("GetTXTForDomain failed: [%v]", err)
+	}
+	if len(txts) != 0 {
+		t.Errorf("Expected TXT rows to be removed, got %v", txts)
+	}
+
+	if err := DB.DeleteDomain(reg.Subdomain); !errors.Is(err, acmedns.ErrDomainNotFound) {
+		t.Errorf("Expected ErrDomainNotFound for second delete, got [%v]", err)
+	}
+	if err := DB.DeleteDomain("does-not-exist"); !errors.Is(err, acmedns.ErrDomainNotFound) {
+		t.Errorf("Expected ErrDomainNotFound for unknown domain, got [%v]", err)
+	}
+}
+
+func TestDeleteDomainErrors(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Could not create sqlmock: %v", err)
+	}
+	defer func(db *sql.DB) {
+		_ = db.Close()
+	}(mockDB)
+	oldDb := DB.GetBackend()
+	DB.SetBackend(mockDB)
+	defer DB.SetBackend(oldDb)
+
+	mock.ExpectBegin().WillReturnError(errors.New("begin error"))
+	if err := DB.DeleteDomain("sub"); err == nil {
+		t.Errorf("Expected begin error, got none")
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM records").WillReturnError(errors.New("exec error"))
+	mock.ExpectRollback()
+	if err := DB.DeleteDomain("sub"); err == nil {
+		t.Errorf("Expected exec error, got none")
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM records").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM txt").WillReturnError(errors.New("txt error"))
+	mock.ExpectRollback()
+	if err := DB.DeleteDomain("sub"); err == nil {
+		t.Errorf("Expected txt exec error, got none")
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM records").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM txt").WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+	if err := DB.DeleteDomain("sub"); err != nil {
+		t.Errorf("Expected successful delete, got [%v]", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unmet sqlmock expectations: %v", err)
+	}
+}

--- a/pkg/nameserver/challenge.go
+++ b/pkg/nameserver/challenge.go
@@ -30,7 +30,7 @@ func (c *ChallengeProvider) AppendRecords(ctx context.Context, zone string, recs
 	}
 
 	for _, s := range c.servers {
-		s.PersonalKeyAuth = token
+		s.SetPersonalKeyAuth(token)
 	}
 	return recs, nil
 }
@@ -41,7 +41,7 @@ func (c *ChallengeProvider) DeleteRecords(ctx context.Context, zone string, recs
 		log.WithFields(log.Fields{"name": item.RR().Name, "value": item.RR().Data, "type": item.RR().Type}).Info("Attempting to unset dns record")
 	}
 	for _, s := range c.servers {
-		s.PersonalKeyAuth = ""
+		s.SetPersonalKeyAuth("")
 	}
 	return recs, nil
 }

--- a/pkg/nameserver/nameserver.go
+++ b/pkg/nameserver/nameserver.go
@@ -1,14 +1,24 @@
 package nameserver
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"codeberg.org/miekg/dns"
+	"codeberg.org/miekg/dns/dnsutil"
+	"codeberg.org/miekg/dns/rdata"
 	"github.com/hm-edu/acme-dns/pkg/acmedns"
-	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
+
+// ednsUDPSize is the EDNS0 UDP payload size advertised in responses to EDNS0 queries.
+// 1232 bytes is the value recommended by DNS flag day 2020 and fits within the
+// server's receive buffer (dns.DefaultMsgSize).
+const ednsUDPSize = 1232
 
 // Records is a slice of ResourceRecords
 type Records struct {
@@ -17,31 +27,46 @@ type Records struct {
 
 // DNSServer is the main struct for acme-dns DNS server
 type DNSServer struct {
-	DB              acmedns.Database
-	Domain          string
-	Server          *dns.Server
-	SOA             dns.RR
-	PersonalKeyAuth string
-	Domains         map[string]Records
+	DB      acmedns.Database
+	Domain  string
+	Server  *dns.Server
+	SOA     dns.RR
+	Domains map[string]Records
+
+	// personalKeyAuth holds the TXT value served for the server's own
+	// _acme-challenge record. It is written by the ACME challenge provider and
+	// read by the DNS handler goroutines, hence the atomic access.
+	personalKeyAuth atomic.Value
+}
+
+// SetPersonalKeyAuth sets the TXT value served for the server's own _acme-challenge record
+func (d *DNSServer) SetPersonalKeyAuth(token string) {
+	d.personalKeyAuth.Store(token)
+}
+
+// PersonalKeyAuth returns the TXT value served for the server's own _acme-challenge record
+func (d *DNSServer) PersonalKeyAuth() string {
+	v, _ := d.personalKeyAuth.Load().(string)
+	return v
 }
 
 // New creates and returns a new DNSServer
 func New(db acmedns.Database, addr string, proto string, domain string) *DNSServer {
-	var server DNSServer
+	server := &DNSServer{}
 	server.Server = &dns.Server{Addr: addr, Net: proto}
+	server.Server.Handler = dns.HandlerFunc(server.handleRequest)
 	if !strings.HasSuffix(domain, ".") {
 		domain = domain + "."
 	}
 	server.Domain = strings.ToLower(domain)
 	server.DB = db
-	server.PersonalKeyAuth = ""
+	server.SetPersonalKeyAuth("")
 	server.Domains = make(map[string]Records)
-	return &server
+	return server
 }
 
 // Start starts the DNSServer
 func (d *DNSServer) Start(errorChannel chan error) {
-	dns.HandleFunc(".", d.handleRequest)
 	log.WithFields(log.Fields{"addr": d.Server.Addr, "proto": d.Server.Net}).Info("Listening DNS")
 	err := d.Server.ListenAndServe()
 	if err != nil {
@@ -52,9 +77,13 @@ func (d *DNSServer) Start(errorChannel chan error) {
 // ParseRecords parses a slice of DNS record strings from the config
 func (d *DNSServer) ParseRecords(config acmedns.DNSConfig) {
 	for _, v := range config.General.StaticRecords {
-		rr, err := dns.NewRR(strings.ToLower(v))
-		if err != nil {
-			log.WithFields(log.Fields{"error": err.Error(), "rr": v}).Warning("Could not parse RR from config")
+		rr, err := dns.New(strings.ToLower(v))
+		if err != nil || rr == nil {
+			errstr := "empty record"
+			if err != nil {
+				errstr = err.Error()
+			}
+			log.WithFields(log.Fields{"error": errstr, "rr": v}).Warning("Could not parse RR from config")
 			continue
 		}
 		d.appendRR(rr)
@@ -65,9 +94,13 @@ func (d *DNSServer) ParseRecords(config acmedns.DNSConfig) {
 		strings.ToLower(config.General.Nsname),
 		strings.ToLower(config.General.Nsadmin),
 		serial)
-	soarr, err := dns.NewRR(SOAstring)
-	if err != nil {
-		log.WithFields(log.Fields{"error": err.Error(), "soa": SOAstring}).Error("Error while adding SOA record")
+	soarr, err := dns.New(SOAstring)
+	if err != nil || soarr == nil {
+		errstr := "empty record"
+		if err != nil {
+			errstr = err.Error()
+		}
+		log.WithFields(log.Fields{"error": errstr, "soa": SOAstring}).Error("Error while adding SOA record")
 	} else {
 		d.appendRR(soarr)
 		d.SOA = soarr
@@ -84,31 +117,33 @@ func (d *DNSServer) appendRR(rr dns.RR) {
 		drecs.Records = append(drecs.Records, rr)
 		d.Domains[addDomain] = drecs
 	}
-	log.WithFields(log.Fields{"recordtype": dns.TypeToString[rr.Header().Rrtype], "domain": addDomain}).Debug("Adding new record to domain")
+	log.WithFields(log.Fields{"recordtype": dnsutil.TypeToString(dns.RRToType(rr)), "domain": addDomain}).Debug("Adding new record to domain")
 }
 
-func (d *DNSServer) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
-	m := new(dns.Msg)
-	m.SetReply(r)
-
-	opt := r.IsEdns0()
-	if opt != nil {
-		if opt.Version() != 0 {
-			//nolint:staticcheck
-			m.MsgHdr.Rcode = dns.RcodeBadVers
-			m.SetEdns0(512, false)
-		} else {
-			m.SetEdns0(512, false)
-			if r.Opcode == dns.OpcodeQuery {
-				d.readQuery(m)
-			}
-		}
-	} else {
-		if r.Opcode == dns.OpcodeQuery {
-			d.readQuery(m)
-		}
+func (d *DNSServer) handleRequest(_ context.Context, w dns.ResponseWriter, r *dns.Msg) {
+	// The server only decodes the header and question section before invoking the
+	// handler, decode the rest so EDNS0 information becomes available.
+	if err := r.Unpack(); err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Debug("Could not unpack DNS message")
+		return
 	}
-	_ = w.WriteMsg(m)
+	m := new(dns.Msg)
+	dnsutil.SetReply(m, r)
+
+	// r.UDPSize is only set when the request carried an EDNS0 OPT record.
+	hasEDNS := r.UDPSize > 0
+	if hasEDNS {
+		// RFC 6891: a response to an EDNS0 query must carry an OPT record.
+		m.UDPSize = ednsUDPSize
+	}
+	if hasEDNS && r.Version != 0 {
+		m.Rcode = dns.RcodeBadVers
+	} else if r.Opcode == dns.OpcodeQuery {
+		d.readQuery(m)
+	}
+	if _, err := io.Copy(w, m); err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Debug("Could not write DNS response")
+	}
 }
 
 func (d *DNSServer) readQuery(m *dns.Msg) {
@@ -118,33 +153,31 @@ func (d *DNSServer) readQuery(m *dns.Msg) {
 			if auth {
 				authoritative = auth
 			}
-			//nolint:staticcheck
-			m.MsgHdr.Rcode = rc
+			m.Rcode = rc
 			m.Answer = append(m.Answer, rr...)
 		}
 	}
-	//nolint:staticcheck
-	m.MsgHdr.Authoritative = authoritative
-	if authoritative {
-		//nolint:staticcheck
-		if m.MsgHdr.Rcode == dns.RcodeNameError {
-			m.Ns = append(m.Ns, d.SOA)
-		}
+	m.Authoritative = authoritative
+	if authoritative && m.Rcode == dns.RcodeNameError && d.SOA != nil {
+		m.Ns = append(m.Ns, d.SOA)
 	}
 }
 
-func (d *DNSServer) getRecord(q dns.Question) ([]dns.RR, error) {
+func (d *DNSServer) getRecord(q dns.RR) ([]dns.RR, error) {
 	var rr []dns.RR
 	var cnames []dns.RR
-	domain, ok := d.Domains[strings.ToLower(q.Name)]
+	qname := q.Header().Name
+	qtype := dns.RRToType(q)
+	domain, ok := d.Domains[strings.ToLower(qname)]
 	if !ok {
-		return rr, fmt.Errorf("no records for domain %s", q.Name)
+		return rr, fmt.Errorf("no records for domain %s", qname)
 	}
 	for _, ri := range domain.Records {
-		if ri.Header().Rrtype == q.Qtype {
+		rtype := dns.RRToType(ri)
+		if rtype == qtype {
 			rr = append(rr, ri)
 		}
-		if ri.Header().Rrtype == dns.TypeCNAME {
+		if rtype == dns.TypeCNAME {
 			cnames = append(cnames, ri)
 		}
 	}
@@ -162,11 +195,11 @@ func (d *DNSServer) answeringForDomain(name string) bool {
 	return ok
 }
 
-func (d *DNSServer) isAuthoritative(q dns.Question) bool {
-	if d.answeringForDomain(q.Name) {
+func (d *DNSServer) isAuthoritative(name string) bool {
+	if d.answeringForDomain(name) {
 		return true
 	}
-	domainParts := strings.Split(strings.ToLower(q.Name), ".")
+	domainParts := strings.Split(strings.ToLower(name), ".")
 	for i := range domainParts {
 		if d.answeringForDomain(strings.Join(domainParts[i:], ".")) {
 			return true
@@ -191,17 +224,19 @@ func (d *DNSServer) isOwnChallenge(name string) bool {
 	return false
 }
 
-func (d *DNSServer) answer(q dns.Question) ([]dns.RR, int, bool, error) {
-	var rcode int
+func (d *DNSServer) answer(q dns.RR) ([]dns.RR, uint16, bool, error) {
+	var rcode uint16
 	var err error
 	var txtRRs []dns.RR
-	var authoritative = d.isAuthoritative(q)
-	if !d.isOwnChallenge(q.Name) && !d.answeringForDomain(q.Name) {
+	qname := q.Header().Name
+	qtype := dns.RRToType(q)
+	var authoritative = d.isAuthoritative(qname)
+	if !d.isOwnChallenge(qname) && !d.answeringForDomain(qname) {
 		rcode = dns.RcodeNameError
 	}
 	r, _ := d.getRecord(q)
-	if q.Qtype == dns.TypeTXT {
-		if d.isOwnChallenge(q.Name) {
+	if qtype == dns.TypeTXT {
+		if d.isOwnChallenge(qname) {
 			txtRRs, err = d.answerOwnChallenge(q)
 		} else {
 			txtRRs, err = d.answerTXT(q)
@@ -213,13 +248,13 @@ func (d *DNSServer) answer(q dns.Question) ([]dns.RR, int, bool, error) {
 	if len(r) > 0 {
 		rcode = dns.RcodeSuccess
 	}
-	log.WithFields(log.Fields{"qtype": dns.TypeToString[q.Qtype], "domain": q.Name, "rcode": dns.RcodeToString[rcode]}).Debug("Answering question for domain")
+	log.WithFields(log.Fields{"qtype": dnsutil.TypeToString(qtype), "domain": qname, "rcode": dnsutil.RcodeToString(rcode)}).Debug("Answering question for domain")
 	return r, rcode, authoritative, nil
 }
 
-func (d *DNSServer) answerTXT(q dns.Question) ([]dns.RR, error) {
+func (d *DNSServer) answerTXT(q dns.RR) ([]dns.RR, error) {
 	var ra []dns.RR
-	subdomain := acmedns.SanitizeDomainQuestion(q.Name)
+	subdomain := acmedns.SanitizeDomainQuestion(q.Header().Name)
 	atxt, err := d.DB.GetTXTForDomain(subdomain)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to get record")
@@ -227,18 +262,19 @@ func (d *DNSServer) answerTXT(q dns.Question) ([]dns.RR, error) {
 	}
 	for _, v := range atxt {
 		if len(v) > 0 {
-			r := new(dns.TXT)
-			r.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 1}
-			r.Txt = append(r.Txt, v)
-			ra = append(ra, r)
+			ra = append(ra, newTXT(q.Header().Name, v))
 		}
 	}
 	return ra, nil
 }
 
-func (d *DNSServer) answerOwnChallenge(q dns.Question) ([]dns.RR, error) {
-	r := new(dns.TXT)
-	r.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 1}
-	r.Txt = append(r.Txt, d.PersonalKeyAuth)
-	return []dns.RR{r}, nil
+func (d *DNSServer) answerOwnChallenge(q dns.RR) ([]dns.RR, error) {
+	return []dns.RR{newTXT(q.Header().Name, d.PersonalKeyAuth())}, nil
+}
+
+func newTXT(name string, value string) *dns.TXT {
+	return &dns.TXT{
+		Hdr: dns.Header{Name: name, Class: dns.ClassINET, TTL: 1},
+		TXT: rdata.TXT{Txt: []string{value}},
+	}
 }

--- a/pkg/nameserver/nameserver_test.go
+++ b/pkg/nameserver/nameserver_test.go
@@ -1,6 +1,7 @@
 package nameserver
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -10,10 +11,11 @@ import (
 	"sync"
 	"testing"
 
+	"codeberg.org/miekg/dns"
+	"codeberg.org/miekg/dns/dnsutil"
 	testdb "github.com/erikstmartin/go-testdb"
 	"github.com/hm-edu/acme-dns/pkg/acmedns"
 	"github.com/hm-edu/acme-dns/pkg/database"
-	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -68,14 +70,14 @@ func TestMain(m *testing.M) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	testDNSServer.Server.NotifyStartedFunc = func() {
+	testDNSServer.Server.NotifyStartedFunc = func(context.Context) {
 		wg.Done()
 	}
 	go testDNSServer.Start(make(chan error, 1))
 	wg.Wait()
 
 	exitval := m.Run()
-	_ = testDNSServer.Server.Shutdown()
+	testDNSServer.Server.Shutdown(context.Background())
 	testDB.Close()
 	os.Exit(exitval)
 }
@@ -85,16 +87,14 @@ type resolver struct {
 }
 
 func (r *resolver) lookup(host string, qtype uint16) (*dns.Msg, error) {
-	msg := new(dns.Msg)
-	msg.Id = dns.Id()
-	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{Name: dns.Fqdn(host), Qtype: qtype, Qclass: dns.ClassINET}
-	in, err := dns.Exchange(msg, r.server)
+	msg := dns.NewMsg(host, qtype)
+	msg.ID = dns.ID()
+	in, err := dns.Exchange(context.Background(), msg, "udp", r.server)
 	if err != nil {
 		return in, fmt.Errorf("Error querying the server [%v]", err)
 	}
 	if in != nil && in.Rcode != dns.RcodeSuccess {
-		return in, fmt.Errorf("Received error from the server [%s]", dns.RcodeToString[in.Rcode])
+		return in, fmt.Errorf("Received error from the server [%s]", dnsutil.RcodeToString(in.Rcode))
 	}
 	return in, nil
 }
@@ -132,7 +132,7 @@ func TestQuestionDBError(t *testing.T) {
 	testDB.SetBackend(tdb)
 	defer testDB.SetBackend(oldDb)
 
-	q := dns.Question{Name: dns.Fqdn("whatever.tld"), Qtype: dns.TypeTXT, Qclass: dns.ClassINET}
+	q := &dns.TXT{Hdr: dns.Header{Name: dnsutil.Fqdn("whatever.tld"), Class: dns.ClassINET}}
 	_, err = testDNSServer.answerTXT(q)
 	if err == nil {
 		t.Errorf("Expected error but got none")
@@ -152,6 +152,9 @@ func TestParse(t *testing.T) {
 	testDNSServer.ParseRecords(testcfg)
 	if !loggerHasEntryWithMessage("Error while adding SOA record") {
 		t.Errorf("Expected SOA parsing to return error, but did not find one")
+	}
+	if !loggerHasEntryWithMessage("Could not parse RR from config") {
+		t.Errorf("Expected unparseable static record to be logged, but did not find one")
 	}
 }
 
@@ -176,45 +179,40 @@ func TestEDNS(t *testing.T) {
 	resolv := resolver{server: "127.0.0.1:15353"}
 	answer, _ := resolv.lookup("auth.example.org", dns.TypeOPT)
 	if answer.Rcode != dns.RcodeSuccess {
-		t.Errorf("Was expecing NOERROR rcode for OPT query, but got [%s] instead.", dns.RcodeToString[answer.Rcode])
+		t.Errorf("Was expecing NOERROR rcode for OPT query, but got [%s] instead.", dnsutil.RcodeToString(answer.Rcode))
 	}
 }
 
 func TestEDNSA(t *testing.T) {
-	msg := new(dns.Msg)
-	msg.Id = dns.Id()
-	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{Name: dns.Fqdn("auth.example.org"), Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	msg.SetEdns0(512, true)
-	in, err := dns.Exchange(msg, "127.0.0.1:15353")
+	msg := dns.NewMsg("auth.example.org", dns.TypeA)
+	msg.ID = dns.ID()
+	msg.UDPSize = 512
+	msg.Security = true
+	in, err := dns.Exchange(context.Background(), msg, "udp", "127.0.0.1:15353")
 	if err != nil {
-		t.Errorf("Error querying the server [%v]", err)
+		t.Fatalf("Error querying the server [%v]", err)
 	}
-	if in != nil && in.Rcode != dns.RcodeSuccess {
-		t.Errorf("Received error from the server [%s]", dns.RcodeToString[in.Rcode])
+	if in.Rcode != dns.RcodeSuccess {
+		t.Errorf("Received error from the server [%s]", dnsutil.RcodeToString(in.Rcode))
 	}
-	opt := in.IsEdns0()
-	if opt == nil {
+	if in.UDPSize == 0 {
 		t.Errorf("Should have got OPT back")
 	}
 }
 
 func TestEDNSBADVERS(t *testing.T) {
-	msg := new(dns.Msg)
-	msg.Id = dns.Id()
-	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{Name: dns.Fqdn("auth.example.org"), Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	o := new(dns.OPT)
+	msg := dns.NewMsg("auth.example.org", dns.TypeA)
+	msg.ID = dns.ID()
+	// Pack does not honour msg.Version, so add a raw OPT RR with version 1 to the additional section.
+	o := &dns.OPT{Hdr: dns.Header{Name: "."}}
 	o.SetVersion(1)
-	o.Hdr.Name = "."
-	o.Hdr.Rrtype = dns.TypeOPT
 	msg.Extra = append(msg.Extra, o)
-	in, err := dns.Exchange(msg, "127.0.0.1:15353")
+	in, err := dns.Exchange(context.Background(), msg, "udp", "127.0.0.1:15353")
 	if err != nil {
-		t.Errorf("Error querying the server [%v]", err)
+		t.Fatalf("Error querying the server [%v]", err)
 	}
-	if in != nil && in.Rcode != dns.RcodeBadVers {
-		t.Errorf("Received unexpected rcode from the server [%s]", dns.RcodeToString[in.Rcode])
+	if in.Rcode != dns.RcodeBadVers {
+		t.Errorf("Received unexpected rcode from the server [%s]", dnsutil.RcodeToString(in.Rcode))
 	}
 }
 
@@ -226,10 +224,10 @@ func TestResolveCNAME(t *testing.T) {
 		t.Errorf("Got unexpected error: %s", err)
 	}
 	if len(answer.Answer) != 1 {
-		t.Errorf("Expected exactly 1 RR in answer, but got %d instead.", len(answer.Answer))
+		t.Fatalf("Expected exactly 1 RR in answer, but got %d instead.", len(answer.Answer))
 	}
-	if answer.Answer[0].Header().Rrtype != dns.TypeCNAME {
-		t.Errorf("Expected a CNAME answer, but got [%s] instead.", dns.TypeToString[answer.Answer[0].Header().Rrtype])
+	if dns.RRToType(answer.Answer[0]) != dns.TypeCNAME {
+		t.Errorf("Expected a CNAME answer, but got [%s] instead.", dnsutil.TypeToString(dns.RRToType(answer.Answer[0])))
 	}
 	if answer.Answer[0].String() != expected {
 		t.Errorf("Expected CNAME answer [%s] but got [%s] instead.", expected, answer.Answer[0].String())
@@ -240,24 +238,22 @@ func TestAuthoritative(t *testing.T) {
 	resolv := resolver{server: "127.0.0.1:15353"}
 	answer, _ := resolv.lookup("nonexistent.auth.example.org", dns.TypeA)
 	if answer.Rcode != dns.RcodeNameError {
-		t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dns.RcodeToString[answer.Rcode])
+		t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dnsutil.RcodeToString(answer.Rcode))
 	}
 	if len(answer.Ns) != 1 {
-		t.Errorf("Was expecting exactly one answer (SOA) for invalid subdomain, but got %d", len(answer.Ns))
+		t.Fatalf("Was expecting exactly one answer (SOA) for invalid subdomain, but got %d", len(answer.Ns))
 	}
-	if answer.Ns[0].Header().Rrtype != dns.TypeSOA {
-		t.Errorf("Was expecting SOA record as answer for NXDOMAIN but got [%s]", dns.TypeToString[answer.Ns[0].Header().Rrtype])
+	if dns.RRToType(answer.Ns[0]) != dns.TypeSOA {
+		t.Errorf("Was expecting SOA record as answer for NXDOMAIN but got [%s]", dnsutil.TypeToString(dns.RRToType(answer.Ns[0])))
 	}
-	//nolint:staticcheck
-	if !answer.MsgHdr.Authoritative {
+	if !answer.Authoritative {
 		t.Errorf("Was expecting authoritative bit to be set")
 	}
 	nanswer, _ := resolv.lookup("nonexsitent.nonauth.tld", dns.TypeA)
 	if len(nanswer.Answer) > 0 {
 		t.Errorf("Didn't expect answers for non authotitative domain query")
 	}
-	//nolint:staticcheck
-	if nanswer.MsgHdr.Authoritative {
+	if nanswer.Authoritative {
 		t.Errorf("Authoritative bit should not be set for non-authoritative domain.")
 	}
 }
@@ -300,7 +296,7 @@ func TestResolveTXT(t *testing.T) {
 		}
 
 		if len(answer.Answer) > 0 {
-			if !test.getAnswer && answer.Answer[0].Header().Rrtype != dns.TypeSOA {
+			if !test.getAnswer && dns.RRToType(answer.Answer[0]) != dns.TypeSOA {
 				t.Errorf("Test %d: Expected no answer, but got: [%q]", i, answer)
 			}
 			if test.getAnswer {
@@ -323,6 +319,20 @@ func TestResolveTXT(t *testing.T) {
 	}
 }
 
+func TestOwnChallenge(t *testing.T) {
+	resolv := resolver{server: "127.0.0.1:15353"}
+	testDNSServer.SetPersonalKeyAuth("own-challenge-token")
+	defer testDNSServer.SetPersonalKeyAuth("")
+
+	answer, err := resolv.lookup("_acme-challenge.auth.example.org", dns.TypeTXT)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+	if err := hasExpectedTXTAnswer(answer.Answer, "own-challenge-token"); err != nil {
+		t.Errorf("Expected own challenge token in answer: %v", err)
+	}
+}
+
 func TestCaseInsensitiveResolveA(t *testing.T) {
 	resolv := resolver{server: "127.0.0.1:15353"}
 	answer, err := resolv.lookup("aUtH.eXAmpLe.org", dns.TypeA)
@@ -339,7 +349,7 @@ func TestCaseInsensitiveResolveSOA(t *testing.T) {
 	resolv := resolver{server: "127.0.0.1:15353"}
 	answer, _ := resolv.lookup("doesnotexist.aUtH.eXAmpLe.org", dns.TypeSOA)
 	if answer.Rcode != dns.RcodeNameError {
-		t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dns.RcodeToString[answer.Rcode])
+		t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dnsutil.RcodeToString(answer.Rcode))
 	}
 
 	if len(answer.Ns) == 0 {


### PR DESCRIPTION
- Implemented unit tests for admin API endpoints including authentication, domain listing, retrieval, reporting, and TXT record management.
- Added database functions for counting, listing, retrieving, and deleting domains, along with handling associated TXT records.
- Enhanced error handling in database operations and ensured proper transaction management during domain deletions.
- Utilized sqlmock for simulating database interactions in tests, ensuring robust coverage for various scenarios including error cases.